### PR TITLE
chore(ci): fix renovate configuration

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,8 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>retailnext/renovate-config",
+    "config:best-practices",
+    ":semanticCommits",
+    "regexManagers:dockerfileVersions",
+    "regexManagers:githubActionsVersions",
     ":automergeAll",
     ":gitSignOff"
+  ],
+  "labels": [
+    "dependencies"
   ]
 }


### PR DESCRIPTION
Because this is a public repository, Renovate refuses to load our (private) default settings repo. Adding the relevant bits here inline instead.